### PR TITLE
readme(style): add conventional branch to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,15 @@ We use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/), i
 - `feat(scope): message` for new features and additions
 - `fix(scope): message` for bugfixes and the likes
 
-### Examples:
+### Examples
 - `feat(ACL): Added graph search`
 - `fix(serialization): ACL's now load correctly on startup`
+
+# Branch style
+We use [conventional branch](https://conventional-branch.github.io/), where branches are named as `type/description`:
+- `type` can be `feat`, `fix`, `chore`, etc.
+- `description` must be lowercase alphanumerical and separated with hyphens (`-`).
+
+### Examples
+- `feat/userset-resolver`
+- `fix/conventional-autofix-commit-messages`


### PR DESCRIPTION
Conventional branch seems cool. It'll make our branch names more manageable, just like the conventional commit style does.