### PR TITLE
feat(acl): Zanzibar-style ACL serialization

### DIFF
--- a/src/acl.ts
+++ b/src/acl.ts
@@ -12,6 +12,10 @@ export class Obj {
         this.type = type;
         this.identifier = identifier;
     }
+
+    toString(): string {
+        return `${this.type}:${this.identifier}`;
+    }
 }
 
 export type RelationName = string;
@@ -25,6 +29,10 @@ export class UserSet {
     constructor(object: Obj, relation: RelationName) {
         this.object = object;
         this.relationName = relation;
+    }
+
+    toString(): string {
+        return `${this.object.toString()}#${this.relationName}`;
     }
 }
 
@@ -42,5 +50,10 @@ export class Relation {
         this.object = object;
         this.name = relation;
         this.subject = subject;
+    }
+
+    // Same serialization style as the Zanzibar paper https://authzed.com/zanzibar
+    toString(): string {
+        return `${this.object.toString()}#${this.name}@${this.subject.toString()}`;
     }
 }

--- a/src/graph.ts
+++ b/src/graph.ts
@@ -92,7 +92,7 @@ describe("graph", () => {
         let Gertrud = 3;
         let Martin = 4;
 
-        let egdes: Relation[] = [
+        let edges: Relation[] = [
             new Relation(mortenEhr, "viewer", new UserSet(læge, "member")),
             new Relation(læge, "member", new UserSet(overLæge, "admin")),
             new Relation(læge, "member", new UserSet(overLæge, "member")),
@@ -104,7 +104,7 @@ describe("graph", () => {
             new Relation(overLæge, "ASS!!", Martin),
         ];
 
-        let graph = new Graph(vertices, egdes);
+        let graph = new Graph(vertices, edges);
         console.log(graph.edgeStrings());
 
         let users = graph.resolveSubjects2(new UserSet(mortenEhr, "viewer"));

--- a/src/graph.ts
+++ b/src/graph.ts
@@ -17,6 +17,15 @@ class Graph {
         this.edges = edges;
     }
 
+    // Methods for printing contents of a graph
+    vertexStrings(): string[] {
+        return this.vertices.map((vertex) => vertex.toString());
+    }
+
+    edgeStrings(): string[] {
+        return this.edges.map((edge) => edge.toString());
+    }
+
     getRelationsTo(vertex: Vertex): Relation[] {
         if (vertex instanceof Obj) {
             return this.edges.filter((edge) => vertex === edge.object);

--- a/src/graph.ts
+++ b/src/graph.ts
@@ -81,10 +81,10 @@ describe("graph", () => {
         //relation: RelationName;
         //subject: Subject;
 
-        let mortenEhr = new Obj("EHR", "Morten's");
+        let mortenEhr = new Obj("EHR", "morten");
 
-        let læge = new Obj("Group", "Læge");
-        let overLæge = new Obj("Group", "Over Læge");
+        let læge = new Obj("group", "læge");
+        let overLæge = new Obj("group", "overlæge");
 
         let Bob = 0;
         let Alice = 1;
@@ -105,8 +105,10 @@ describe("graph", () => {
         ];
 
         let graph = new Graph(vertices, egdes);
+        console.log(graph.edgeStrings());
 
         let users = graph.resolveSubjects2(new UserSet(mortenEhr, "viewer"));
+        console.log(users);
 
         assert.deepEqual(users, [Bob, Alice, Knud, Gertrud]);
     });


### PR DESCRIPTION
Just provides some methods to serialize ACLs in the same format as the Zanzibar paper. As an example, the `resolveSubjects` test now also prints all the relations that it will test the traversal through: 
```bash
[
  'EHR:morten#viewer@group:læge#member',
  'group:læge#member@group:overlæge#admin',
  'group:læge#member@group:overlæge#member',
  'group:overlæge#admin@0',
  'group:overlæge#member@1',
  'group:læge#member@2',
  'EHR:morten#viewer@1',
  'EHR:morten#viewer@3',
  'group:overlæge#ASS!!@4'
]
```