### PR TITLE
fix: lint whole codebase

### DIFF
--- a/src/graph.ts
+++ b/src/graph.ts
@@ -62,6 +62,7 @@ export default class Graph {
         /**
          * Takes in a default JS object, and converts it into the correct type.
          */
+        /* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-return, @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call */
         const reviver = (_key: string, val: any) => {
             if (typeof val !== "object" || Array.isArray(val)) return val;
 
@@ -138,7 +139,9 @@ export default class Graph {
                 `Graph JSON has invalid object "${JSON.stringify(val)}"`
             );
         };
+        /* eslint-enable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-return, @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call */
 
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
         const graph: Graph = JSON.parse(json, reviver);
 
         return graph;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import express from "express";
+import type { Request } from "express";
 import bodyParser from "body-parser";
 import { Obj, UserSet } from "./acl.ts";
 import { deserializeConfig } from "./serialize.ts";
@@ -10,9 +11,14 @@ const graph = await deserializeConfig();
 
 app.use(bodyParser.json());
 
-app.get("/authorize", (req, res) => {
-    //   "/user/:UserId/relation/:RelationName/objectId/:ObjectId/type/:Type",
+interface AuthorizeBody {
+    ObjectId: string;
+    RelationName: string;
+    Type: string;
+    UserId: string;
+}
 
+app.get("/authorize", (req: Request<unknown, unknown, AuthorizeBody>, res) => {
     console.log(
         req.body.ObjectId,
         req.body.RelationName,
@@ -20,9 +26,9 @@ app.get("/authorize", (req, res) => {
         req.body.UserId
     );
 
-    let object = new Obj(req.body.Type, req.body.ObjectId);
+    const object = new Obj(req.body.Type, req.body.ObjectId);
 
-    let users = graph.resolveSubjects(
+    const users = graph.resolveSubjects(
         new UserSet(object, req.body.RelationName)
     );
 
@@ -38,5 +44,5 @@ app.get("/authorize", (req, res) => {
 });
 
 app.listen(port, () => {
-    console.log(`Example app listening on port ${port}`);
+    console.log(`Example app listening on port ${port.toString()}`);
 });

--- a/src/typeconfig.ts
+++ b/src/typeconfig.ts
@@ -57,7 +57,8 @@ export class Typeconfig implements TypeconfigData {
             path,
             JSON.stringify(
                 this,
-                (_, value) => (value instanceof Set ? [...value] : value), // this is needed because JSON can't stringify Sets
+                (_, value): unknown =>
+                    value instanceof Set ? [...value] : value, // this is needed because JSON can't stringify Sets
                 2
             )
         );
@@ -118,7 +119,7 @@ export class Typeconfig implements TypeconfigData {
         } catch (error) {
             if (error instanceof TypeconfigError) {
                 throw new TypeconfigError(
-                    `Error on line ${lineNumber} ("${line.trim()}")\n  -> ${error.message}`,
+                    `Error on line ${lineNumber.toString()} ("${line.trim()}")\n  -> ${error.message}`,
                     { cause: error }
                 );
             }
@@ -127,6 +128,7 @@ export class Typeconfig implements TypeconfigData {
     }
 
     private static handlePermission(tokens: string[], state: TypeconfigState) {
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
         const [_, permissionName, equalsSign, ...logicTokens] = tokens;
         if (!permissionName || equalsSign !== "=" || logicTokens.length === 0) {
             throw new TypeconfigError(
@@ -188,7 +190,7 @@ export class Typeconfig implements TypeconfigData {
         const [command, target, ...extra] = tokens;
         if (!command || !target || extra.length > 0) {
             throw new TypeconfigError(
-                `Relation must have 2 tokens (e.g. "give owner"), got ${tokens.length}`
+                `Relation must have 2 tokens (e.g. "give owner"), got ${tokens.length.toString()}`
             );
         }
         if (command === "give") {
@@ -222,7 +224,7 @@ export class Typeconfig implements TypeconfigData {
 
         if (!keyword || !value) {
             throw new TypeconfigError(
-                `Header must have at least 2 tokens (e.g. "type doc", "relation viewer", "permission can_view = viewer"), got ${tokens.length}.`
+                `Header must have at least 2 tokens (e.g. "type doc", "relation viewer", "permission can_view = viewer"), got ${tokens.length.toString()}.`
             );
         }
 
@@ -230,7 +232,7 @@ export class Typeconfig implements TypeconfigData {
             case "type": {
                 if (extra.length > 0) {
                     throw new TypeconfigError(
-                        `"type" definition should only have 2 tokens, got ${tokens.length}.`
+                        `"type" definition should only have 2 tokens, got ${tokens.length.toString()}.`
                     );
                 }
                 if (typeof state.type === "string") {
@@ -244,7 +246,7 @@ export class Typeconfig implements TypeconfigData {
             case "relation": {
                 if (extra.length > 0) {
                     throw new TypeconfigError(
-                        `"relation" definition should only have 2 tokens, got ${tokens.length}.`
+                        `"relation" definition should only have 2 tokens, got ${tokens.length.toString()}.`
                     );
                 }
                 if (state.validRelations.has(value)) {

--- a/tests/typeconfig.test.ts
+++ b/tests/typeconfig.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, before, after } from "node:test";
+import { describe, it, before } from "node:test";
 import { promises as fs } from "node:fs";
 import assert, { strict } from "node:assert";
 import { Typeconfig } from "../src/typeconfig.ts";
@@ -25,16 +25,6 @@ permission write = editor OR owner
 permission delete = owner
 `;
         await fs.writeFile(validTestFilePath, validConfig);
-    });
-
-    // clean up temporary files after tests run
-    after(async () => {
-        const files = [validTestFilePath, errorTestFilePath, outFilePath];
-        for (const file of files) {
-            try {
-                await fs.unlink(file);
-            } catch {}
-        }
     });
 
     it("should successfully parse a valid config file", async () => {
@@ -67,7 +57,21 @@ permission delete = owner
         await config.saveToFile(outFilePath);
 
         const readJSON = await fs.readFile(outFilePath, "utf-8");
-        const parsedJSON = JSON.parse(readJSON);
+
+        interface JsonParsedTypeconfig {
+            type: string;
+            validRelations: string[];
+            relations: {
+                affected: string;
+                give: string[];
+            }[];
+            permissions: {
+                name: string;
+                grantedBy: string[];
+            }[];
+        }
+
+        const parsedJSON = JSON.parse(readJSON) as JsonParsedTypeconfig;
 
         strict.equal(parsedJSON.type, "doc");
 
@@ -95,7 +99,7 @@ permission read = viewer OR
         await assert.rejects(
             // assert.rejects means we expect the promise to reject, which is the async equivalent of throwing
             async () => await Typeconfig.fromFile(errorTestFilePath),
-            (err: any) => {
+            (err: unknown) => {
                 assert.ok(err instanceof TypeconfigError);
                 assert.match(err.message, /Malformed permission logic/);
                 return true;
@@ -117,7 +121,7 @@ relation viewer
 
         await assert.rejects(
             async () => await Typeconfig.fromFile(errorTestFilePath),
-            (err: any) => {
+            (err: unknown) => {
                 assert.ok(err instanceof TypeconfigError);
                 assert.match(err.message, /is already defined/);
                 return true;
@@ -135,7 +139,7 @@ permission read = viewer
 
         await assert.rejects(
             async () => await Typeconfig.fromFile(errorTestFilePath),
-            (err: any) => {
+            (err: unknown) => {
                 assert.ok(err instanceof TypeconfigError);
                 assert.match(err.message, /No type was ever specified/);
                 return true;


### PR DESCRIPTION
looked at all 70+ problems reported when running `npx eslint .` and resolved them / ignored some.

the ones i ignored were in the reviver for deserializing config.json; @KneeCapStealer, please take a look at where i added `eslint-disable` comments and consider whether its even possible to avoid these when we are reviving stuff that really COULD be `any`? perchance the `unknown` type could fix all these problems?