### PR TITLE
feat: validation with Zod

### DIFF
--- a/examples/config.json
+++ b/examples/config.json
@@ -1,0 +1,95 @@
+{
+  "vertices": [],
+  "edges": [
+    {
+      "object": {
+        "type": "EHR",
+        "identifier": "Morten's"
+      },
+      "name": "viewer",
+      "subject": {
+        "object": {
+          "type": "Group",
+          "identifier": "Læge"
+        },
+        "relationName": "member"
+      }
+    },
+    {
+      "object": {
+        "type": "Group",
+        "identifier": "Læge"
+      },
+      "name": "member",
+      "subject": {
+        "object": {
+          "type": "Group",
+          "identifier": "Over Læge"
+        },
+        "relationName": "admin"
+      }
+    },
+    {
+      "object": {
+        "type": "Group",
+        "identifier": "Læge"
+      },
+      "name": "member",
+      "subject": {
+        "object": {
+          "type": "Group",
+          "identifier": "Over Læge"
+        },
+        "relationName": "member"
+      }
+    },
+    {
+      "object": {
+        "type": "Group",
+        "identifier": "Over Læge"
+      },
+      "name": "admin",
+      "subject": 0
+    },
+    {
+      "object": {
+        "type": "Group",
+        "identifier": "Over Læge"
+      },
+      "name": "member",
+      "subject": 1
+    },
+    {
+      "object": {
+        "type": "Group",
+        "identifier": "Læge"
+      },
+      "name": "member",
+      "subject": 2
+    },
+    {
+      "object": {
+        "type": "EHR",
+        "identifier": "Morten's"
+      },
+      "name": "viewer",
+      "subject": 1
+    },
+    {
+      "object": {
+        "type": "EHR",
+        "identifier": "Morten's"
+      },
+      "name": "viewer",
+      "subject": 3
+    },
+    {
+      "object": {
+        "type": "Group",
+        "identifier": "Over Læge"
+      },
+      "name": "ASS!!",
+      "subject": 4
+    }
+  ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "body-parser": "^2.2.2",
-        "express": "^5.2.1"
+        "express": "^5.2.1",
+        "zod": "^4.4.1"
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
@@ -2249,6 +2250,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.1.tgz",
+      "integrity": "sha512-a6ENMBBGZBsnlSebQ/eKCguSBeGKSf4O7BPnqVPmYGtpBYI7VSqoVqw+QcB7kPRjbqPwhYTpFbVj/RqNz/CT0Q==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "license": "AGPL-3.0-or-later",
   "author": "Me",
   "type": "module",
-  "main": "./dist/index.js",
+  "main": "./dist/src/index.js",
   "scripts": {
     "test": "node --test --test-global-setup=./tests/setup.ts",
     "build": "tsc",
@@ -45,6 +45,7 @@
   },
   "dependencies": {
     "body-parser": "^2.2.2",
-    "express": "^5.2.1"
+    "express": "^5.2.1",
+    "zod": "^4.4.1"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,46 +1,52 @@
 import express from "express";
-import type { Request } from "express";
-import bodyParser from "body-parser";
-import { Obj, UserSet } from "./acl.ts";
+import { z } from "zod";
+import { Obj, Relation, UserSet } from "./acl.ts";
 import { deserializeConfig } from "./serialize.ts";
 
 const app = express();
 const port = 3000;
-
 const graph = await deserializeConfig();
+app.use(express.json()); // turns out body-parser isnt needed, express has its own json middleware
 
-app.use(bodyParser.json());
+const AuthorizeQuerySchema = z.object({
+    ObjectId: z.string().min(1), // .min(1) ensures no empty strings. without it, /authorize?ObjectId=&... would be valid input
+    RelationName: z.string().min(1),
+    Type: z.string().min(1),
+    UserId: z.coerce.number().min(1), // we coerce because the input will be something like "1" and we want 1
+});
 
-interface AuthorizeBody {
-    ObjectId: string;
-    RelationName: string;
-    Type: string;
-    UserId: string;
-}
+app.get("/authorize", (req, res) => {
+    const result = AuthorizeQuerySchema.safeParse(req.query);
 
-app.get("/authorize", (req: Request<unknown, unknown, AuthorizeBody>, res) => {
-    console.log(
-        req.body.ObjectId,
-        req.body.RelationName,
-        req.body.Type,
-        req.body.UserId
-    );
+    if (!result.success) {
+        res.status(400).json({
+            error: "Invalid query parameters",
+            details: z.treeifyError(result.error),
+        });
+        return;
+    }
 
-    const object = new Obj(req.body.Type, req.body.ObjectId);
+    // at this point we know that the request fits the schema, so the types are ensured
+    const { Type, ObjectId, RelationName, UserId } = result.data;
 
-    const users = graph.resolveSubjects(
-        new UserSet(object, req.body.RelationName)
-    );
+    const relation = new Relation(
+        new Obj(Type, ObjectId),
+        RelationName,
+        UserId
+    ); // merely constructing this to include its zanzibar-style string form in the response
 
-    console.log(users);
+    const object = new Obj(Type, ObjectId);
+    const users = graph.resolveSubjects(new UserSet(object, RelationName));
 
-    res.statusCode = 200;
-
-    if (users.has(Number(req.body.UserId))) {
-        res.send("The docter has permission to the file");
-    } else res.send("The doctor does not have persmission to the file");
-
-    res.end();
+    if (users.has(UserId)) {
+        res.status(200).send(
+            `Relation <code>${relation.toString()}</code> exists; permission granted`
+        );
+    } else {
+        res.status(403).send(
+            `Relation <code>${relation.toString()}</code> does not exist; permission denied`
+        ); // 401 Unauthorized seems more fitting, but for some reason, it actually means Unauthenticated. Known misnomer. 403 is standard for when the user is actually unauthorized
+    }
 });
 
 app.listen(port, () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,17 +12,19 @@ const AuthorizeQuerySchema = z.object({
     ObjectId: z.string().min(1), // .min(1) ensures no empty strings. without it, /authorize?ObjectId=&... would be valid input
     RelationName: z.string().min(1),
     Type: z.string().min(1),
-    UserId: z.coerce.number().min(1), // we coerce because the input will be something like "1" and we want 1
+    UserId: z.coerce.number().min(0), // we coerce because the input will be something like "1" and we want 1
 });
 
 app.get("/authorize", (req, res) => {
     const result = AuthorizeQuerySchema.safeParse(req.query);
 
     if (!result.success) {
-        res.status(400).json({
-            error: "Invalid query parameters",
-            details: z.treeifyError(result.error),
-        });
+        res.status(400)
+            .contentType("application/json")
+            .json({
+                error: "Invalid query parameters",
+                details: z.treeifyError(result.error),
+            });
         return;
     }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,6 @@
     // For nodejs:
     "lib": ["esnext"],
     "types": ["node", "express"],
-
     // Other Outputs
     "sourceMap": true,
     "declaration": true,
@@ -34,10 +33,9 @@
     "noUncheckedSideEffectImports": true,
     "moduleDetection": "force",
     "skipLibCheck": true,
-
     // Custom
-    "rewriteRelativeImportExtensions": true,
-    "allowImportingTsExtensions": true
+    "rewriteRelativeImportExtensions": true
+    //"allowImportingTsExtensions": true
   },
   "exclude": ["./dist/**/*"],
   "include": ["./src/**/*", "./tests/**/*", "./eslint.config.js"]


### PR DESCRIPTION
adds `zod`, the most popular library for validation of stuff in typescript. changes the contents of `index.ts` to use Zod validation on the `/authorize` endpoint, mostly just for an example of how it might be used. Also fixes the `npm run serve` script as it used to point to `dist/index.js`; our recent changes to the tsconfig has made the compiled index.js actually live at `dist/src/index.js`.