### PR TITLE
Rewrite fromjson with propper typeguard and better tests

### DIFF
--- a/src/acl.ts
+++ b/src/acl.ts
@@ -68,31 +68,50 @@ export function isObject(value: unknown): value is JsonObject {
     return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
+/**
+ * Tests wether an object is _shaped_ like an `Obj`.
+ */
 export function isObjShape(o: JsonObject): o is {
-    type: unknown;
-    identifier: unknown;
+    type: Type;
+    identifier: ObjectId;
 } {
-    return "type" in o && "identifier" in o;
+    return (
+        "type" in o &&
+        typeof o.type === "string" &&
+        "identifier" in o &&
+        typeof o.identifier === "string"
+    );
 }
 
+/**
+ * Tests wether an object is _shaped_ like a `UserSet`.
+ */
 export function isUserSetShape(o: JsonObject): o is {
-    object: unknown;
-    relationName: unknown;
+    object: Obj;
+    relationName: RelationName;
 } {
-    return "object" in o && "relationName" in o;
+    return (
+        "object" in o &&
+        o.object instanceof Obj &&
+        "relationName" in o &&
+        typeof o.relationName === "string"
+    );
 }
 
+/**
+ * Tests wether an object is _shaped_ like a `Relation`.
+ */
 export function isRelationShape(o: JsonObject): o is {
-    object: unknown;
-    name: unknown;
-    subject: unknown;
+    object: Obj;
+    name: RelationName;
+    subject: Subject;
 } {
-    return "object" in o && "name" in o && "subject" in o;
-}
-
-export function isGraphShape(o: JsonObject): o is {
-    vertices: unknown;
-    edges: unknown;
-} {
-    return "vertices" in o && "edges" in o;
+    return (
+        "object" in o &&
+        o.object instanceof Obj &&
+        "name" in o &&
+        typeof o.name === "string" &&
+        "subject" in o &&
+        (typeof o.subject === "number" || o.subject instanceof UserSet)
+    );
 }

--- a/src/acl.ts
+++ b/src/acl.ts
@@ -61,3 +61,38 @@ export class Relation {
         return `${this.object.toString()}#${this.name}@${this.subject.toString()}`;
     }
 }
+
+export type JsonObject = Record<string, unknown>;
+
+export function isObject(value: unknown): value is JsonObject {
+    return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export function isObjShape(o: JsonObject): o is {
+    type: unknown;
+    identifier: unknown;
+} {
+    return "type" in o && "identifier" in o;
+}
+
+export function isUserSetShape(o: JsonObject): o is {
+    object: unknown;
+    relationName: unknown;
+} {
+    return "object" in o && "relationName" in o;
+}
+
+export function isRelationShape(o: JsonObject): o is {
+    object: unknown;
+    name: unknown;
+    subject: unknown;
+} {
+    return "object" in o && "name" in o && "subject" in o;
+}
+
+export function isGraphShape(o: JsonObject): o is {
+    vertices: unknown;
+    edges: unknown;
+} {
+    return "vertices" in o && "edges" in o;
+}

--- a/src/graph.ts
+++ b/src/graph.ts
@@ -1,7 +1,33 @@
 import type { Subject, UserId } from "./acl.ts";
-import { Obj, Relation, UserSet } from "./acl.ts";
+import {
+    Obj,
+    Relation,
+    UserSet,
+    isObject,
+    isObjShape,
+    isUserSetShape,
+    isRelationShape,
+    type JsonObject,
+} from "./acl.ts";
 
 type Vertex = Obj | UserId;
+
+/**
+ * Tests wether an object is _shaped_ like a `Graph`.
+ */
+export function isGraphShape(o: JsonObject): o is {
+    vertices: Vertex[];
+    edges: Relation[];
+} {
+    return (
+        "vertices" in o &&
+        Array.isArray(o.vertices) &&
+        o.vertices.every((v) => typeof v === "number" || v instanceof Obj) &&
+        "edges" in o &&
+        Array.isArray(o.edges) &&
+        o.edges.every((e) => e instanceof Relation)
+    );
+}
 
 /**
  * Graph containing relations and vertices between them.
@@ -48,101 +74,37 @@ export default class Graph {
      * @throws {Error} if `json` has invalid configuration.
      */
     static fromJSON(json: string): Graph {
-        const isRelation = (o: object) =>
-            Object.hasOwn(o, "object") &&
-            Object.hasOwn(o, "name") &&
-            Object.hasOwn(o, "subject");
-        const isObj = (o: object) =>
-            Object.hasOwn(o, "type") && Object.hasOwn(o, "identifier");
-        const isUserSet = (o: object) =>
-            Object.hasOwn(o, "object") && Object.hasOwn(o, "relationName");
-        const isGraph = (o: object) =>
-            Object.hasOwn(o, "vertices") && Object.hasOwn(o, "edges");
-
-        /**
-         * Takes in a default JS object, and converts it into the correct type.
-         */
-        /* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-return, @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call */
-        const reviver = (_key: string, val: any) => {
-            if (typeof val !== "object" || Array.isArray(val)) return val;
-
-            if (isRelation(val)) {
-                if (!(val.object instanceof Obj)) {
-                    throw new Error(
-                        `Relations 'object' field is not of type 'Obj', ${JSON.stringify(val.object)}`
-                    );
-                }
-
-                if (typeof val.name !== "string") {
-                    throw new Error(
-                        `Relations 'name' field is not of type 'string', ${JSON.stringify(val.name)}`
-                    );
-                }
-
-                if (
-                    typeof val.subject !== "number" &&
-                    !(val.subject instanceof UserSet)
-                ) {
-                    throw new Error(
-                        `Relations 'subject' field is not of type 'UserId' or 'UserSet', ${JSON.stringify(val.subject)}`
-                    );
-                }
-
-                return new Relation(val.object, val.name, val.subject);
+        const reviver = (_key: string, val: unknown): unknown => {
+            if (!isObject(val)) {
+                return val;
             }
 
-            if (isObj(val)) {
-                if (typeof val.type !== "string") {
-                    throw new Error(
-                        `Objs 'type' field is not of type 'string', ${JSON.stringify(val.type)}`
-                    );
-                }
-
-                if (typeof val.identifier !== "string") {
-                    throw new Error(
-                        `Objs 'identifier' field is not of type 'string', ${JSON.stringify(val.identifier)}`
-                    );
-                }
-
+            if (isObjShape(val)) {
                 return new Obj(val.type, val.identifier);
             }
 
-            if (isUserSet(val)) {
-                if (!(val.object instanceof Obj)) {
-                    throw new Error(
-                        `UserSets 'object' field not of type 'Obj': ${JSON.stringify(val.object)}`
-                    );
-                }
-
-                if (typeof val.relationName !== "string") {
-                    throw new Error(
-                        `UserSets 'relationName' field is not of type 'string', ${JSON.stringify(val.relationName)}`
-                    );
-                }
-
+            if (isUserSetShape(val)) {
                 return new UserSet(val.object, val.relationName);
             }
 
-            if (isGraph(val)) {
-                if (!val.edges.every((rel: any) => rel instanceof Relation)) {
-                    throw new Error(
-                        "The graphs 'edges' field contains object which is not of type 'Relation'"
-                    );
-                }
+            if (isRelationShape(val)) {
+                return new Relation(val.object, val.name, val.subject);
+            }
 
-                // TODO: Apply same check for vertices when they are used
-
+            if (isGraphShape(val)) {
                 return new Graph(val.vertices, val.edges);
             }
 
             throw new Error(
-                `Graph JSON has invalid object "${JSON.stringify(val)}"`
+                `Invalid object shape in json: ${JSON.stringify(val)}`
             );
         };
-        /* eslint-enable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-return, @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call */
 
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-        const graph: Graph = JSON.parse(json, reviver);
+        const graph: unknown = JSON.parse(json, reviver);
+
+        if (!(graph instanceof Graph)) {
+            throw new Error("JSON did not contain a Graph");
+        }
 
         return graph;
     }

--- a/tests/graph.test.ts
+++ b/tests/graph.test.ts
@@ -31,7 +31,7 @@ describe("A graph", () => {
 
         const users = graph.resolveSubjects(new UserSet(mortenEhr, "viewer"));
 
-        expect(users).toEqual(new Set([Bob, Alice, Knud, Gertrud]));
+        expect(users).toStrictEqual(new Set([Bob, Alice, Knud, Gertrud]));
     });
 
     it("should find the target (DFS)", () => {
@@ -78,6 +78,6 @@ describe("A graph", () => {
         const graph = new Graph([], with_loop);
 
         const users = graph.resolveSubjects(new UserSet(mortenEhr, "viewer"));
-        expect(users).toEqual(new Set([Bob, Alice, Knud, Gertrud]));
+        expect(users).toStrictEqual(new Set([Bob, Alice, Knud, Gertrud]));
     });
 });

--- a/tests/serialize.test.ts
+++ b/tests/serialize.test.ts
@@ -20,7 +20,7 @@ describe("Serialization", { timeout: 1000 }, () => {
 
         const read = await fs.readFile("./config.json");
 
-        expect(read.toString()).toBe(
+        expect(read.toString()).toStrictEqual(
             '{"vertices":[],"edges":[{"object":{"type":"EHR","identifier":"mortenEHR"},"name":"viewer","subject":{"object":{"type":"group","identifier":"læge"},"relationName":"member"}}]}'
         );
     });
@@ -55,6 +55,6 @@ describe("Serialization", { timeout: 1000 }, () => {
 
         const deserializedGraph = await deserializeConfig();
 
-        expect(deserializedGraph).toEqual(graph);
+        expect(deserializedGraph).toStrictEqual(graph);
     });
 });

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -5,6 +5,6 @@ export default defineConfig({
         globals: false,
         setupFiles: ["./tests/helpers/setup.ts"],
         fileParallelism: false, // this is true by default, and sadly it causes a race condition
-        exclude: ["./dist/**/*", "./node_modules/**/*"],
+        include: ["./tests/**/*.test.ts"],
     },
 });


### PR DESCRIPTION
# changes:
- Add typeguard functions called `IsFooShape`.
  - They assert wether an object is _shaped_ like a class, this does not mean they are that class.
- Update `Graph.fromJSON` to use the typeguards to massively simplify it
- Misc. feature: Use strict equality in testing

This should make the reviver a lot nicer to read.