### PR TITLE
fix(serialization): edge object references

### DIFF
--- a/src/graph.ts
+++ b/src/graph.ts
@@ -123,7 +123,51 @@ export default class Graph {
             }
 
             if (isGraphShape(val)) {
-                return new Graph(val.vertices, val.edges);
+                const graph = new Graph(val.vertices, val.edges);
+                // make sure all objects in the edges are references to objects in the vertices array.
+                graph.edges = graph.edges.map((edge) => {
+                    // First find the object in the vertices array which corresponds to the "object" member of the edge
+                    const to: Obj = edge.object;
+                    const actualTo = graph.vertices.find((v) =>
+                        verticesAreEqual(v, to)
+                    );
+                    if (!(actualTo instanceof Obj)) {
+                        throw new Error(
+                            `Edge has object not found in vertices. Object: "${to.toString()}"`
+                        );
+                    }
+
+                    let subject: Subject;
+                    if (edge.subject instanceof UserSet) {
+                        // If the "subject" member of the edge is a UserSet, find the object in the UserSet
+                        const object = edge.subject.object;
+                        const actualFrom = graph.vertices.find((v) =>
+                            verticesAreEqual(v, object)
+                        );
+                        if (!(actualFrom instanceof Obj))
+                            throw new Error(
+                                `Edge userset object not defined in vertices. Object: "${object.toString()}"`
+                            );
+
+                        subject = new UserSet(
+                            actualFrom,
+                            edge.subject.relationName
+                        );
+                    } else {
+                        // If the "subject" member of the edge is a UserId, make sure it is defined.
+                        if (!graph.vertices.includes(edge.subject))
+                            throw new Error(
+                                `Edge has user not defined in vertices. UserID: "${edge.subject}"`
+                            );
+
+                        subject = edge.subject;
+                    }
+
+                    // We now have correct references to objects in the "vertices array"
+                    return new Relation(actualTo, edge.name, subject);
+                });
+
+                return graph;
             }
 
             throw new Error(

--- a/src/graph.ts
+++ b/src/graph.ts
@@ -157,7 +157,7 @@ export default class Graph {
                         // If the "subject" member of the edge is a UserId, make sure it is defined.
                         if (!graph.vertices.includes(edge.subject))
                             throw new Error(
-                                `Edge has user not defined in vertices. UserID: "${edge.subject}"`
+                                `Edge has user not defined in vertices. UserID: "${edge.subject.toString()}"`
                             );
 
                         subject = edge.subject;

--- a/tests/graph.test.ts
+++ b/tests/graph.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { Obj, Relation, UserSet } from "../src/acl.ts";
-import Graph from "../src/graph.ts";
+import Graph, { type Vertex } from "../src/graph.ts";
 
 describe("A graph", () => {
     const mortenEhr = new Obj("EHR", "Morten's");
@@ -8,76 +8,81 @@ describe("A graph", () => {
     const læge = new Obj("Group", "Læge");
     const overLæge = new Obj("Group", "Over Læge");
 
-    const Bob = 0;
-    const Alice = 1;
-    const Knud = 2;
-    const Gertrud = 3;
-    const Martin = 4;
+    const bob = 0;
+    const alice = 1;
+    const knud = 2;
+    const gertrud = 3;
+    const martin = 4;
+    const morten = 5;
+    const ib = 6; // not used in the edges
+
+    const vertices: Vertex[] = [
+        mortenEhr,
+        læge,
+        overLæge,
+        morten,
+        bob,
+        alice,
+        knud,
+        gertrud,
+        martin,
+        ib,
+    ];
 
     const edges: Relation[] = [
         new Relation(mortenEhr, "viewer", new UserSet(læge, "member")),
         new Relation(læge, "member", new UserSet(overLæge, "admin")),
         new Relation(læge, "member", new UserSet(overLæge, "member")),
-        new Relation(overLæge, "admin", Bob),
-        new Relation(overLæge, "member", Alice),
-        new Relation(læge, "member", Knud),
-        new Relation(mortenEhr, "viewer", Alice),
-        new Relation(mortenEhr, "viewer", Gertrud),
-        new Relation(overLæge, "ASS!!", Martin),
+        new Relation(overLæge, "admin", bob),
+        new Relation(overLæge, "member", alice),
+        new Relation(læge, "member", knud),
+        new Relation(mortenEhr, "viewer", alice),
+        new Relation(mortenEhr, "viewer", gertrud),
+        new Relation(overLæge, "ASS!!", martin),
     ];
 
+    const g = new Graph(vertices, edges);
+
     it("should resolve all subjects", () => {
-        const graph = new Graph([], edges);
+        const graph = g.clone();
 
         const users = graph.resolveSubjects(new UserSet(mortenEhr, "viewer"));
 
-        expect(users).toStrictEqual(new Set([Bob, Alice, Knud, Gertrud]));
+        expect(users).toStrictEqual(new Set([bob, alice, knud, gertrud]));
     });
 
     it("should find the target (DFS)", () => {
-        const graph = new Graph([], edges);
+        const graph = g.clone();
         const userset = new UserSet(mortenEhr, "viewer");
 
-        expect(graph.DFS(Bob, userset)).toBeTruthy();
-        expect(graph.DFS(Alice, userset)).toBeTruthy();
-        expect(graph.DFS(Knud, userset)).toBeTruthy();
-        expect(graph.DFS(Gertrud, userset)).toBeTruthy();
-        expect(graph.DFS(Bob, Bob)).toBeTruthy();
+        expect(graph.DFS(bob, userset)).toBeTruthy();
+        expect(graph.DFS(alice, userset)).toBeTruthy();
+        expect(graph.DFS(knud, userset)).toBeTruthy();
+        expect(graph.DFS(gertrud, userset)).toBeTruthy();
+        expect(graph.DFS(bob, bob)).toBeTruthy();
 
-        expect(graph.DFS(Martin, userset)).toBeFalsy();
-        expect(graph.DFS(Bob, 37)).toBeFalsy();
+        expect(graph.DFS(martin, userset)).toBeFalsy();
+        expect(graph.DFS(bob, 37)).toBeFalsy();
         expect(
-            graph.DFS(Bob, new UserSet(mortenEhr, "silkeborger"))
+            graph.DFS(bob, new UserSet(mortenEhr, "silkeborger"))
         ).toBeFalsy();
     });
 
     it("should find the target (DFS) and handle loops", () => {
-        const with_loop = edges.concat([
-            new Relation(overLæge, "member", new UserSet(læge, "member")),
-        ]);
-        const graph = new Graph([], with_loop);
+        const graph = g.clone();
+        graph.addEdge(overLæge, "member", new UserSet(læge, "member"));
         const userset = new UserSet(mortenEhr, "viewer");
 
-        expect(graph.DFS(Bob, userset)).toBeTruthy();
-        expect(graph.DFS(Alice, userset)).toBeTruthy();
-        expect(graph.DFS(Knud, userset)).toBeTruthy();
-        expect(graph.DFS(Gertrud, userset)).toBeTruthy();
-        expect(graph.DFS(Bob, Bob)).toBeTruthy();
+        expect(graph.DFS(bob, userset)).toBeTruthy();
+        expect(graph.DFS(alice, userset)).toBeTruthy();
+        expect(graph.DFS(knud, userset)).toBeTruthy();
+        expect(graph.DFS(gertrud, userset)).toBeTruthy();
+        expect(graph.DFS(bob, bob)).toBeTruthy();
 
-        expect(graph.DFS(Martin, userset)).toBeFalsy();
+        expect(graph.DFS(martin, userset)).toBeFalsy();
         expect(graph.DFS(0, 37)).toBeFalsy();
         expect(
-            graph.DFS(Bob, new UserSet(mortenEhr, "silkeborger"))
+            graph.DFS(bob, new UserSet(mortenEhr, "silkeborger"))
         ).toBeFalsy();
-    });
-
-    it("should resolve subject and handle loops", () => {
-        const with_loop = edges.concat([
-            new Relation(overLæge, "member", new UserSet(læge, "member")),
-        ]);
-        const graph = new Graph([], with_loop);
-
-        const users = graph.resolveSubjects(new UserSet(mortenEhr, "viewer"));
-        expect(users).toStrictEqual(new Set([Bob, Alice, Knud, Gertrud]));
     });
 });

--- a/tests/serialize.test.ts
+++ b/tests/serialize.test.ts
@@ -1,27 +1,27 @@
 import { describe, it, expect } from "vitest";
 import { promises as fs } from "node:fs";
 import { Obj, Relation, UserSet } from "../src/acl.ts";
-import Graph from "../src/graph.ts";
+import Graph, { type Vertex } from "../src/graph.ts";
 import { serializeConfig, deserializeConfig } from "../src/serialize.ts";
 
 describe("Serialization", { timeout: 1000 }, () => {
     it("should serialize a simple graph", async () => {
+        const mortenEHR = new Obj("EHR", "mortenEHR");
+        const læge = new Obj("group", "læge");
+
+        const vertices: Vertex[] = [mortenEHR, læge];
         const edges: Relation[] = [
-            new Relation(
-                new Obj("EHR", "mortenEHR"),
-                "viewer",
-                new UserSet(new Obj("group", "læge"), "member")
-            ),
+            new Relation(mortenEHR, "viewer", new UserSet(læge, "member")),
         ];
 
-        const graph = new Graph([], edges);
+        const graph = new Graph(vertices, edges);
 
         await serializeConfig(graph);
 
         const read = await fs.readFile("./config.json");
 
         expect(read.toString()).toStrictEqual(
-            '{"vertices":[],"edges":[{"object":{"type":"EHR","identifier":"mortenEHR"},"name":"viewer","subject":{"object":{"type":"group","identifier":"læge"},"relationName":"member"}}]}'
+            '{"vertices":[{"type":"EHR","identifier":"mortenEHR"},{"type":"group","identifier":"læge"}],"edges":[{"object":{"type":"EHR","identifier":"mortenEHR"},"name":"viewer","subject":{"object":{"type":"group","identifier":"læge"},"relationName":"member"}}]}'
         );
     });
 
@@ -30,26 +30,41 @@ describe("Serialization", { timeout: 1000 }, () => {
     const læge = new Obj("Group", "Læge");
     const overLæge = new Obj("Group", "Over Læge");
 
-    const Bob = 0;
-    const Alice = 1;
-    const Knud = 2;
-    const Gertrud = 3;
-    const Martin = 4;
+    const bob = 0;
+    const alice = 1;
+    const knud = 2;
+    const gertrud = 3;
+    const martin = 4;
+    const morten = 5;
+    const ib = 6; // not used in the edges
+
+    const vertices: Vertex[] = [
+        mortenEhr,
+        læge,
+        overLæge,
+        morten,
+        bob,
+        alice,
+        knud,
+        gertrud,
+        martin,
+        ib,
+    ];
 
     const edges: Relation[] = [
         new Relation(mortenEhr, "viewer", new UserSet(læge, "member")),
         new Relation(læge, "member", new UserSet(overLæge, "admin")),
         new Relation(læge, "member", new UserSet(overLæge, "member")),
-        new Relation(overLæge, "admin", Bob),
-        new Relation(overLæge, "member", Alice),
-        new Relation(læge, "member", Knud),
-        new Relation(mortenEhr, "viewer", Alice),
-        new Relation(mortenEhr, "viewer", Gertrud),
-        new Relation(overLæge, "ASS!!", Martin),
+        new Relation(overLæge, "admin", bob),
+        new Relation(overLæge, "member", alice),
+        new Relation(læge, "member", knud),
+        new Relation(mortenEhr, "viewer", alice),
+        new Relation(mortenEhr, "viewer", gertrud),
+        new Relation(overLæge, "ASS!!", martin),
     ];
 
     it("should serialize the graph", async () => {
-        const graph = new Graph([], edges);
+        const graph = new Graph(vertices, edges);
 
         await serializeConfig(graph);
 


### PR DESCRIPTION
It looks like a lot of changes, but 50% of the changes are me renaming: `Bob` to `bob`, `Alice` to `alice` and so on.

The main addition is: https://github.com/P2-Gruppe-10/lingua-franca/blob/35ac10141931f87c6ed4aef5273f6f0727237482/src/graph.ts#L128-L184

Which seems scary, but the formatter made it 3x longer than it had to be, just read the comments and hopefully it makes sense.