### PR TITLE
feat: save graph to disc every 10 seconds

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import express from "express";
 import { z } from "zod";
 import { Obj, Relation, UserSet, type Subject, type UserId } from "./acl.ts";
-import { deserializeConfig } from "./serialize.ts";
+import { deserializeConfig, serializeConfig } from "./serialize.ts";
 import AuthZ from "./authz.ts";
 
 process.title = "lingua";
@@ -12,6 +12,13 @@ app.use(express.json()); // turns out body-parser isnt needed, express has its o
 const graph = await deserializeConfig();
 const authz = await AuthZ.withDir(graph, "./schemas/");
 authz.validateWithWarnings();
+
+// Save the graph every 10 seconds
+setInterval(() => {
+    serializeConfig(graph).catch((err: unknown) => {
+        console.warn("Failed to serialize graph:", err);
+    });
+}, 10000);
 
 const AuthorizeQuerySchema = z.object({
     objectId: z.string().min(1), // .min(1) ensures no empty strings. without it, /authorize?ObjectId=&... would be valid input


### PR DESCRIPTION
# Changes:
- Use `setInterval` function to call `serializeConfig` every 10_000 milliseconds.
  - Here we must use `.catch` in case `serializeConfig` fails.