### PR TITLE
refactor the endpoint test script to make it more readable

### DIFF
--- a/tests/test-endpoints.sh
+++ b/tests/test-endpoints.sh
@@ -72,9 +72,9 @@ print-body() {
         return
     fi
 
-    if jq empty >/dev/null 2>&1 <<<"$body"; then
+    if jq empty 2>/dev/null <<<"$body"; then
         echo "json response:"
-        jq 2>/dev/null <<<"$body"
+        jq <<<"$body"
     else
         echo "text response:"
         echo "$body"

--- a/tests/test-endpoints.sh
+++ b/tests/test-endpoints.sh
@@ -17,7 +17,7 @@ npm run build || { echo "Build failed"; exit 1; }
 cd "$target_dir" || exit 1
 node "$project_dir" &
 
-server_pid=$!
+readonly server_pid=$!
 
 cleanup() {
     kill $server_pid 
@@ -44,11 +44,11 @@ echo
 echo Running tests...
 echo "---"
 
-RED="\033[0;31m"
-GREEN="\033[0;32m"
-YELLOW="\033[0;33m"
-RESET="\033[0m"
-BOLD="\033[1m"
+readonly RED="\033[0;31m"
+readonly GREEN="\033[0;32m"
+readonly YELLOW="\033[0;33m"
+readonly RESET="\033[0m"
+readonly BOLD="\033[1m"
 
 number_succeeded=0
 number_failed=0

--- a/tests/test-endpoints.sh
+++ b/tests/test-endpoints.sh
@@ -5,6 +5,17 @@ if ! which curl; then
     exit 1
 fi
 
+readonly RED="\033[0;31m"
+readonly GREEN="\033[0;32m"
+readonly YELLOW="\033[0;33m"
+readonly RESET="\033[0m"
+readonly BOLD="\033[1m"
+
+number_succeeded=0
+number_failed=0
+number_expected_failed=0
+number_tests=0
+
 project_dir="$(pwd)"
 target_dir="/tmp/lingua-franca"
 mkdir -p "$target_dir"
@@ -44,16 +55,6 @@ echo
 echo Running tests...
 echo "---"
 
-readonly RED="\033[0;31m"
-readonly GREEN="\033[0;32m"
-readonly YELLOW="\033[0;33m"
-readonly RESET="\033[0m"
-readonly BOLD="\033[1m"
-
-number_succeeded=0
-number_failed=0
-number_expected_failed=0
-number_tests=0
 
 ### TESTING FUNCTIONS ###
 
@@ -112,7 +113,6 @@ endtest-expect-fail() {
         let number_failed++
         echo -e "${RED}✗${RESET}"
     fi
-    number_tests=$(($number_tests + 1))
 
     print-body $curl_body
 }

--- a/tests/test-endpoints.sh
+++ b/tests/test-endpoints.sh
@@ -18,26 +18,6 @@ cd "$target_dir" || exit 1
 node "$project_dir" &
 
 server_pid=$!
-sleep 2 # give it time to start up
-# if server_pid still running after 2 seconds we know it didnt die instantly
-if ! kill -0 $server_pid 2>/dev/null; then
-    echo "failed to run server (process died immediately)"
-    exit 1
-fi
-echo started node server with pid $server_pid
-echo
-echo Running tests...
-echo "---"
-
-RED="\033[0;31m"
-GREEN="\033[0;32m"
-YELLOW="\033[0;33m"
-RESET="\033[0m"
-
-number_succeeded=0
-number_failed=0
-number_expected_failed=0
-number_tests=0
 
 cleanup() {
     kill $server_pid 
@@ -53,12 +33,35 @@ cleanup() {
 # automatically closes node server on ctrl+c
 trap cleanup EXIT
 
+sleep 2 # give it time to start up
+# if server_pid still running after 2 seconds we know it didnt die instantly
+if ! kill -0 $server_pid 2>/dev/null; then
+    echo "failed to run server (process died immediately)"
+    exit 1
+fi
+echo started node server with pid $server_pid
+echo
+echo Running tests...
+echo "---"
+
+RED="\033[0;31m"
+GREEN="\033[0;32m"
+YELLOW="\033[0;33m"
+RESET="\033[0m"
+BOLD="\033[1m"
+
+number_succeeded=0
+number_failed=0
+number_expected_failed=0
+number_tests=0
+
+
 
 current_test_name=""
 
 runtest() {
     current_test_name=$1
-    printf "\033[1m$1\033[0m... "
+    printf "$BOLD$1$RESET... "
 }
 
 
@@ -93,7 +96,7 @@ endtest-if-failed() {
 
 endtest-expect-fail() {
     # was the status code not a success code, or the last command failed
-    if [[ "$1" != "2"* ]] || [[ $curl_exit != 0 ]]; then
+    if [[ $curl_exit != 0 ]]; then
         echo -e "${YELLOW}✓${RESET}"
         number_expected_failed=$(($number_expected_failed + 1))
     else
@@ -132,11 +135,10 @@ do-curl localhost:3000/subjects \
         -H "Accept: application/json" \
         --max-time 5 \
         --fail-with-body \
-        --silent \
-        --output /dev/null \
-        --write-out "%{http_code}" # only get the status code of the result
+        --silent
+)
 
-endtest-expect-fail "$curl_body"
+endtest-expect-fail
 
 # test for delete subject
 runtest "delete subject"

--- a/tests/test-endpoints.sh
+++ b/tests/test-endpoints.sh
@@ -8,6 +8,7 @@ fi
 readonly RED="\033[0;31m"
 readonly GREEN="\033[0;32m"
 readonly YELLOW="\033[0;33m"
+readonly BLUE="\033[0;34m"
 readonly RESET="\033[0m"
 readonly BOLD="\033[1m"
 
@@ -34,7 +35,7 @@ cleanup() {
     kill $server_pid 
     rm -rf "$target_dir"
     echo "---"
-    echo "$number_tests tests completed"
+    echo -e "${BLUE}${RESET} $number_tests tests completed"
     echo -e "${GREEN}✓ $number_succeeded passed${RESET}"
     echo -e "${YELLOW}~ $number_expected_failed expected failures${RESET}"
     echo -e "${RED}✗ $number_failed failed${RESET}"
@@ -67,11 +68,11 @@ runtest() {
 
 print-body() {
     local body="$@"
-
     if [[ $body == "" ]]; then
         return
     fi
 
+    # Check if $body is JSON or not
     if jq empty 2>/dev/null <<<"$body"; then
         echo "json response:"
         jq <<<"$body"
@@ -85,15 +86,13 @@ endtest() {
     local exit_code=$1
     let number_tests++
     if [[ $exit_code != 0 ]]; then
-        echo -e "${RED}failed test: \"$current_test_name\"${RESET}"
+        echo -e "${RED}✗${RESET}"
         let number_failed++
+        print-body $curl_body
     else
         let number_succeeded++
         echo -e "${GREEN}✓${RESET}"
-        echo -e "${GREEN}succeeded test: \"$current_test_name\"${RESET}"
     fi
-
-    print-body $curl_body
 }
 
 endtest-if-failed() {
@@ -112,9 +111,8 @@ endtest-expect-fail() {
     else
         let number_failed++
         echo -e "${RED}✗${RESET}"
+        print-body $curl_body
     fi
-
-    print-body $curl_body
 }
 
 do-curl() {
@@ -132,7 +130,6 @@ runtest "add subject"
 user=12
 
 do-curl localhost:3000/subjects \
-||||||| parent of acf6072 (fix: call print-body before endtest)
         -d "{\"userId\": $user}" \
         -H "Content-Type: application/json" \
         -H "Accept: application/json" \
@@ -153,7 +150,6 @@ do-curl localhost:3000/subjects \
         --max-time 5 \
         --fail-with-body \
         --silent
-)
 
 endtest-expect-fail $?
 

--- a/tests/test-endpoints.sh
+++ b/tests/test-endpoints.sh
@@ -65,8 +65,13 @@ runtest() {
 }
 
 print-body() {
-    local body="$1"
-    if [ -n "$body" ] && jq empty >/dev/null 2>&1 <<<"$body"; then
+    local body="$@"
+
+    if [[ $body == "" ]]; then
+        return
+    fi
+
+    if jq empty >/dev/null 2>&1 <<<"$body"; then
         echo "json response:"
         jq 2>/dev/null <<<"$body"
     else
@@ -117,12 +122,17 @@ do-curl() {
     return $? # stored in a variable so endtest can read it after this function returns
 }
 
+
+### TESTS ###
+
+
 # test for add subject
 runtest "add subject"
 
 user=12
 
 do-curl localhost:3000/subjects \
+||||||| parent of acf6072 (fix: call print-body before endtest)
         -d "{\"userId\": $user}" \
         -H "Content-Type: application/json" \
         -H "Accept: application/json" \
@@ -131,6 +141,7 @@ do-curl localhost:3000/subjects \
         --silent
     
 endtest $?
+
 
 # add existing subject twice
 runtest "add existing subject again"
@@ -145,6 +156,7 @@ do-curl localhost:3000/subjects \
 )
 
 endtest-expect-fail $?
+
 
 # test for delete subject
 runtest "delete subject"
@@ -174,6 +186,7 @@ do-curl localhost:3000/objects \
         --silent
 
 endtest $?
+
 
 # test for delete object
 runtest "delete object"
@@ -224,11 +237,11 @@ do-curl localhost:3000/objects \
 
 endtest $?
 
+
 # test for add relation
 runtest "add relation"
 
 # add a subject again
-
 do-curl localhost:3000/subjects \
     -d "{\"userId\": $user}" \
     -H "Content-Type: application/json" \
@@ -260,6 +273,7 @@ do-curl localhost:3000/relations \
         --silent
 
 endtest $?
+
 
 # test for delete relation
 runtest "delete relation"

--- a/tests/test-endpoints.sh
+++ b/tests/test-endpoints.sh
@@ -3,7 +3,7 @@
 if ! which curl; then 
     echo curl not found
     exit 1
-fi   
+fi
 
 project_dir="$(pwd)"
 target_dir="/tmp/lingua-franca"
@@ -54,6 +54,8 @@ number_succeeded=0
 number_failed=0
 number_expected_failed=0
 number_tests=0
+
+### TESTING FUNCTIONS ###
 
 
 current_test_name="No Name"

--- a/tests/test-endpoints.sh
+++ b/tests/test-endpoints.sh
@@ -199,6 +199,8 @@ do-curl localhost:3000/objects?type=EHR\&identifier=Bob \
         --silent
 
 endtest $?
+
+
 # test for modify object
 runtest "modify object"
 
@@ -287,6 +289,7 @@ do-curl "localhost:3000/relations?objectType=EHR&objectIdentifier=Bobs%20leg%20s
 
 endtest $?
 
+
 runtest "authorization"
 
 post_body=$(cat <<END
@@ -319,6 +322,7 @@ do-curl "localhost:3000/authorize?type=EHR&objectId=Bobs%20leg%20surgery&permiss
 
 endtest $?
 
+
 runtest "authorizing on an object that doesn't exist"
 
 do-curl "localhost:3000/authorize?type=EHR&objectId=fortnitepeter2009&permission=can_view&userId=$user" \
@@ -329,7 +333,9 @@ do-curl "localhost:3000/authorize?type=EHR&objectId=fortnitepeter2009&permission
 
 endtest-expect-fail $?
 
+
 runtest "authorizing on a type that doesn't exist"
+
 
 do-curl "localhost:3000/authorize?type=poop&objectId=Bobs%20leg%20surgery&permission=can_view&userId=$user" \
         -H "Accept: application/json" \
@@ -338,6 +344,7 @@ do-curl "localhost:3000/authorize?type=poop&objectId=Bobs%20leg%20surgery&permis
         --silent
 
 endtest-expect-fail $?
+
 
 runtest "authorizing a user that doesn't exist"
 
@@ -348,6 +355,7 @@ do-curl "localhost:3000/authorize?type=EHR&objectId=Bobs%20leg%20surgery&permiss
         --silent
 
 endtest-expect-fail $?
+
 
 runtest "authorizing for a permission that doesn't exist"
 

--- a/tests/test-endpoints.sh
+++ b/tests/test-endpoints.sh
@@ -75,13 +75,14 @@ print-body() {
 
 endtest() {
     local exit_code=$1
-    number_tests=$(($number_tests + 1))
+    let number_tests++
     if [[ $exit_code != 0 ]]; then
         echo -e "${RED}failed test: \"$current_test_name\"${RESET}"
-        number_failed=$(($number_failed + 1))
+        let number_failed++
     else
-        number_succeeded=$(($number_succeeded + 1))
+        let number_succeeded++
         echo -e "${GREEN}✓${RESET}"
+        echo -e "${GREEN}succeeded test: \"$current_test_name\"${RESET}"
     fi
 
     print-body $curl_body
@@ -95,12 +96,13 @@ endtest-if-failed() {
 
 endtest-expect-fail() {
     local exit_code=$1
+    let number_tests++
     # was the status code not a success code, or the last command failed
     if [[ $exit_code != 0 ]]; then
         echo -e "${YELLOW}✓${RESET}"
-        number_expected_failed=$(($number_expected_failed + 1))
+        let number_expected_failed++
     else
-        number_failed=$(($number_failed + 1))
+        let number_failed++
         echo -e "${RED}✗${RESET}"
     fi
     number_tests=$(($number_tests + 1))

--- a/tests/test-endpoints.sh
+++ b/tests/test-endpoints.sh
@@ -56,9 +56,7 @@ number_expected_failed=0
 number_tests=0
 
 
-
-current_test_name=""
-
+current_test_name="No Name"
 runtest() {
     current_test_name=$1
     printf "$BOLD$1$RESET... "

--- a/tests/test-endpoints.sh
+++ b/tests/test-endpoints.sh
@@ -62,6 +62,16 @@ runtest() {
     printf "$BOLD$1$RESET... "
 }
 
+print-body() {
+    local body="$1"
+    if [ -n "$body" ] && jq empty >/dev/null 2>&1 <<<"$body"; then
+        echo "json response:"
+        jq 2>/dev/null <<<"$body"
+    else
+        echo "text response:"
+        echo "$body"
+    fi
+}
 
 endtest() {
     if [[ $curl_exit != 0 ]]; then
@@ -71,19 +81,6 @@ endtest() {
         number_succeeded=$(($number_succeeded + 1))
         echo -e "${GREEN}✓${RESET}"
     fi
-    number_tests=$(($number_tests + 1))
-
-    if [[ $curl_exit != 0 ]]; then
-        if [ -n "$curl_body" ] && jq empty >/dev/null 2>&1 <<<"$curl_body"; then 
-            echo "json response:"
-            jq 2>/dev/null <<<"$curl_body"
-        else
-            echo "text response:"
-            echo "$curl_body"
-        fi
-    fi
-
-    curl_body=""
 }
 
 endtest-if-failed() {

--- a/tests/test-endpoints.sh
+++ b/tests/test-endpoints.sh
@@ -74,24 +74,29 @@ print-body() {
 }
 
 endtest() {
-    if [[ $curl_exit != 0 ]]; then
-        echo -e "${RED}✗${RESET}"
+    local exit_code=$1
+    number_tests=$(($number_tests + 1))
+    if [[ $exit_code != 0 ]]; then
+        echo -e "${RED}failed test: \"$current_test_name\"${RESET}"
         number_failed=$(($number_failed + 1))
     else
         number_succeeded=$(($number_succeeded + 1))
         echo -e "${GREEN}✓${RESET}"
     fi
+
+    print-body $curl_body
 }
 
 endtest-if-failed() {
-    if [[ $curl_exit != 0 ]]; then
-        endtest
+    if [[ $1 != 0 ]]; then
+        endtest $@
     fi
 }
 
 endtest-expect-fail() {
+    local exit_code=$1
     # was the status code not a success code, or the last command failed
-    if [[ $curl_exit != 0 ]]; then
+    if [[ $exit_code != 0 ]]; then
         echo -e "${YELLOW}✓${RESET}"
         number_expected_failed=$(($number_expected_failed + 1))
     else
@@ -99,11 +104,13 @@ endtest-expect-fail() {
         echo -e "${RED}✗${RESET}"
     fi
     number_tests=$(($number_tests + 1))
+
+    print-body $curl_body
 }
 
 do-curl() {
     curl_body=$(curl "$@")
-    curl_exit=$? # stored in a variable so endtest can read it after this function returns
+    return $? # stored in a variable so endtest can read it after this function returns
 }
 
 # test for add subject
@@ -119,7 +126,7 @@ do-curl localhost:3000/subjects \
         --fail-with-body \
         --silent
     
-endtest 
+endtest $?
 
 # add existing subject twice
 runtest "add existing subject again"
@@ -133,7 +140,7 @@ do-curl localhost:3000/subjects \
         --silent
 )
 
-endtest-expect-fail
+endtest-expect-fail $?
 
 # test for delete subject
 runtest "delete subject"
@@ -145,7 +152,7 @@ do-curl "localhost:3000/subjects?userId=$user" \
         --fail-with-body \
         --silent
 
-endtest
+endtest $?
 
 
 # test for add object
@@ -162,7 +169,7 @@ do-curl localhost:3000/objects \
         --fail-with-body \
         --silent
 
-endtest
+endtest $?
 
 # test for delete object
 runtest "delete object"
@@ -174,7 +181,7 @@ do-curl localhost:3000/objects?type=EHR\&identifier=Bob \
         --fail-with-body \
         --silent
 
-endtest
+endtest $?
 # test for modify object
 runtest "modify object"
 
@@ -190,8 +197,8 @@ do-curl localhost:3000/objects \
     --fail-with-body \
     --silent
 
-# if adding bob failed for some reason, end the test
-endtest-if-failed
+# If adding bob failed for some reason, end the test
+endtest-if-failed $?
 
 do-curl localhost:3000/objects \
         -X PUT \
@@ -211,7 +218,7 @@ do-curl localhost:3000/objects \
         --fail-with-body \
         --silent
 
-endtest
+endtest $?
 
 # test for add relation
 runtest "add relation"
@@ -226,7 +233,7 @@ do-curl localhost:3000/subjects \
     --fail-with-body \
     --silent
 
-endtest-if-failed
+endtest-if-failed $?
 
 post_body=$(cat <<END
     {
@@ -248,7 +255,7 @@ do-curl localhost:3000/relations \
         --fail-with-body \
         --silent
 
-endtest
+endtest $?
 
 # test for delete relation
 runtest "delete relation"
@@ -260,7 +267,7 @@ do-curl "localhost:3000/relations?objectType=EHR&objectIdentifier=Bobs%20leg%20s
         --fail-with-body \
         --silent
 
-endtest
+endtest $?
 
 runtest "authorization"
 
@@ -284,7 +291,7 @@ do-curl localhost:3000/relations \
         --fail-with-body \
         --silent
 
-endtest-if-failed 
+endtest-if-failed $?
 
 do-curl "localhost:3000/authorize?type=EHR&objectId=Bobs%20leg%20surgery&permission=can_view&userId=$user" \
         -H "Accept: application/json" \
@@ -292,7 +299,7 @@ do-curl "localhost:3000/authorize?type=EHR&objectId=Bobs%20leg%20surgery&permiss
         --fail-with-body \
         --silent
 
-endtest
+endtest $?
 
 runtest "authorizing on an object that doesn't exist"
 
@@ -302,7 +309,7 @@ do-curl "localhost:3000/authorize?type=EHR&objectId=fortnitepeter2009&permission
         --fail-with-body \
         --silent
 
-endtest-expect-fail "$curl_body"
+endtest-expect-fail $?
 
 runtest "authorizing on a type that doesn't exist"
 
@@ -312,7 +319,7 @@ do-curl "localhost:3000/authorize?type=poop&objectId=Bobs%20leg%20surgery&permis
         --fail-with-body \
         --silent
 
-endtest-expect-fail "$curl_body"
+endtest-expect-fail $?
 
 runtest "authorizing a user that doesn't exist"
 
@@ -322,7 +329,7 @@ do-curl "localhost:3000/authorize?type=EHR&objectId=Bobs%20leg%20surgery&permiss
         --fail-with-body \
         --silent
 
-endtest-expect-fail "$curl_body"
+endtest-expect-fail $?
 
 runtest "authorizing for a permission that doesn't exist"
 
@@ -332,4 +339,4 @@ do-curl "localhost:3000/authorize?type=EHR&objectId=Bobs%20leg%20surgery&permiss
         --fail-with-body \
         --silent
 
-endtest-expect-fail "$curl_body"
+endtest-expect-fail $?


### PR DESCRIPTION
# Changes:
- use `let` instead of the old cursed syntax
- remove useless if statements
- Split printing the body into separate function
- use function arguments.
  Instead of the `$curl_body` global variable we now use `$1` in the functions and call them like so: `endtest $code` and `print-body $body`
- Move cleanup function to the top, so you can `ctrl+c` immediately without consequence.