### PR TITLE
fix(acl): DFS doesn't account for typeconfig

### DIFF
--- a/src/authz.ts
+++ b/src/authz.ts
@@ -128,48 +128,6 @@ export default class AuthZ {
     }
 
     /**
-     * Returns true if the user has a certain relation on an object, whether through direct relation, usersets, computed userset rewrites, or tuple-to-userset rewrites.
-     * */
-    private hasRelation(
-        user: number,
-        object: Obj,
-        relation: string,
-        visited: Set<string> = new Set<string>()
-    ): boolean {
-        const visit = `${object.toString()}#${relation}`;
-        if (visited.has(visit)) return false;
-        visited.add(visit);
-
-        const typeconfig = this.typeconfigs.get(object.type);
-        if (!typeconfig) return false;
-
-        // first handling direct paths through usersets present in the graph
-        if (this.graph.DFS(user, new UserSet(object, relation))) {
-            return true;
-        }
-
-        // then userset rewrites
-        const rewrites = typeconfig.usersetRewrites.get(relation);
-        if (!rewrites) return false; // if there are none, you're out of luck
-
-        for (const rewrite of rewrites) {
-            if (typeof rewrite === "string") {
-                // computed userset
-                if (this.hasRelation(user, object, rewrite, visited)) return true;
-            } else {
-                // tuple-to-userset
-                const targets = this.resolveTargets(object, rewrite.relation);
-                for (const target of targets) {
-                    if (this.hasRelation(user, target, rewrite.subRelation, visited)) {
-                        return true;
-                    }
-                }
-            }
-        }
-        return false; // if none of the previous steps gave us a true, they must not have the relation
-    }
-
-    /**
      * Checks if a UserId has a certain permission on an object of a certain type.
      * Returns false on missing typeconfigs and invalid permission names; make sure to validate the AuthZ system first.
      * */
@@ -183,7 +141,7 @@ export default class AuthZ {
         for (const grant of grantingRelations) {
             // simple case, just look for a relation
             if (typeof grant === "string") {
-                if (this.hasRelation(user, object, grant)) {
+                if (this.graph.DFS(user, new UserSet(object, grant), this)) {
                     return true;
                 }
                 continue; // it's not a rewrite rule but it also didn't give our user the green light, so skip
@@ -191,7 +149,7 @@ export default class AuthZ {
             // otherwise the grant is a rewrite rule
             const targets = this.resolveTargets(object, grant.relation);
             for (const target of targets) {
-                if (this.hasRelation(user, target, grant.subRelation)) {
+                if (this.graph.DFS(user, new UserSet(target, grant.subRelation), this)) {
                     return true;
                 }
             }

--- a/src/authz.ts
+++ b/src/authz.ts
@@ -119,7 +119,7 @@ export default class AuthZ {
     /**
      * Gets all objects in object#... usersets with a certain relation to another object.
      * */
-    private resolveTargets(object: Obj, relation: string): Obj[] {
+    resolveTargets(object: Obj, relation: string): Obj[] {
         return this.graph
             .getRelationsTo(object)
             .filter((edge) => edge.name === relation)

--- a/src/graph.ts
+++ b/src/graph.ts
@@ -1,4 +1,5 @@
 import type { Subject, UserId } from "./acl.ts";
+import AuthZ from "./authz.ts";
 import {
     Obj,
     Relation,
@@ -169,24 +170,50 @@ export default class Graph {
         return graph;
     }
 
-    DFS(target: UserId, subject: Subject): boolean {
+    DFS(target: UserId, subject: Subject, authz?: AuthZ): boolean {
         const stack: Subject[] = [subject];
-        const visited: Set<Subject> = new Set<Subject>();
+        // Is a string because javascript probably uses "Object.Is", while
+        // we want to check for equality
+        const visited: Set<string> = new Set<string>();
 
         while (stack.length > 0) {
             // since the stack is not empty, pop can not return undefined
             // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
             const node = stack.pop()!;
-            if (visited.has(node)) {
+            if (visited.has(node.toString())) {
                 continue;
             }
 
-            visited.add(node);
+            visited.add(node.toString());
 
             if (node === target) return true;
 
             // if our non-target node is not a UserSet, we can't do anything with it, so skip to next iteration
             if (typeof node === "number") continue;
+
+            if (authz !== undefined) {
+                // If there is an authz instance passed in, we want to use potential rewrites.
+                const typeconfig = authz.typeconfigs.get(node.object.type);
+                const rewrites = typeconfig?.usersetRewrites.get(node.relationName);
+                if (rewrites !== undefined) {
+                    for (const rewrite of rewrites) {
+                        // If the given relation has a simple alias rewrite,
+                        // make sure to explore that path later.
+                        if (typeof rewrite === "string") {
+                            stack.push(new UserSet(node.object, rewrite));
+                            continue;
+                        }
+
+                        // If the rewrite is a `RewriteRule` then we have the following scenario
+                        // node.object    <--    target    <--    subject
+                        //             relation        subRelation
+                        //
+                        // And we want to explore all subjects with `subRelation` on `target`:
+                        const targets = authz.resolveTargets(node.object, rewrite.relation);
+                        targets.forEach((target) => stack.push(new UserSet(target, rewrite.subRelation)));
+                    }
+                }
+            }
 
             const subjects = this.getRelationsTo(node.object)
                 // only take the relations which have the correct name

--- a/tests/authz.test.ts
+++ b/tests/authz.test.ts
@@ -21,6 +21,15 @@ function makeDocTypeconfig() {
     );
 }
 
+function makeGroupTypeconfig() {
+    return new Typeconfig(
+        "group",
+        new Set(["member", "admin", "parent"]),
+        new Map([["member", new Set(["admin", { relation: "parent", subRelation: "member" }])]]),
+        new Map()
+    );
+}
+
 function makeFolderTypeconfig() {
     return new Typeconfig(folderType, new Set(["viewer"]), new Map(), new Map());
 }
@@ -64,6 +73,56 @@ describe("AuthZ", () => {
         it("returns true when user has a directly granting relation", () => {
             const graph = new Graph([], [new Relation(docObj, "viewer", userId)]);
             const authz = new AuthZ(graph, new Map([[docType, makeDocTypeconfig()]]));
+
+            expect(authz.hasPermission(userId, docObj, "can_view")).toBe(true);
+        });
+
+        it("returns true when user has an indirectly granting relation", () => {
+            const group = new Obj("group", "test");
+            const graph = new Graph(
+                [],
+                [new Relation(docObj, "viewer", new UserSet(group, "member")), new Relation(group, "member", userId)]
+            );
+            const authz = new AuthZ(graph, new Map([[docType, makeDocTypeconfig()]]));
+
+            expect(authz.hasPermission(userId, docObj, "can_view")).toBe(true);
+        });
+
+        it("returns true when user has an indirectly granting relation, via typeconfig", () => {
+            const group = new Obj("group", "test");
+            const graph = new Graph(
+                [],
+                [new Relation(docObj, "viewer", new UserSet(group, "member")), new Relation(group, "admin", userId)]
+            );
+            const authz = new AuthZ(
+                graph,
+                new Map([
+                    [docType, makeDocTypeconfig()],
+                    ["group", makeGroupTypeconfig()],
+                ])
+            );
+
+            expect(authz.hasPermission(userId, docObj, "can_view")).toBe(true);
+        });
+
+        it("returns true when user has an indirectly granting relation, via tuple to rewrite", () => {
+            const group = new Obj("group", "test");
+            const parent = new Obj("group", "parent");
+            const graph = new Graph(
+                [],
+                [
+                    new Relation(docObj, "viewer", new UserSet(group, "member")),
+                    new Relation(group, "parent", new UserSet(parent, SENTINEL)),
+                    new Relation(parent, "member", userId),
+                ]
+            );
+            const authz = new AuthZ(
+                graph,
+                new Map([
+                    [docType, makeDocTypeconfig()],
+                    ["group", makeGroupTypeconfig()],
+                ])
+            );
 
             expect(authz.hasPermission(userId, docObj, "can_view")).toBe(true);
         });


### PR DESCRIPTION
# Changes:
- Make `Graph.DFS` aware of the typeconfigs
- Remove `Authz.hasRelation` as functionality is ported to `Graph.DFS`
- Add tests to test this new functionality 